### PR TITLE
[fix] subscribe topic bug

### DIFF
--- a/inc/umqtt.h
+++ b/inc/umqtt.h
@@ -78,7 +78,7 @@ enum umqtt_qos { UMQTT_QOS0 = 0, UMQTT_QOS1 = 1, UMQTT_QOS2 = 2, UMQTT_SUBFAIL =
 struct umqtt_client;
 typedef struct umqtt_client *umqtt_client_t;
 typedef int (*umqtt_user_callback)(struct umqtt_client *client, enum umqtt_evt event);
-typedef void (*umqtt_subscribe_cb)(void *client, void *msg);
+typedef void (*umqtt_subscribe_cb)(struct umqtt_client *client, void *msg);
 
 struct subtop_recv_handler
 {

--- a/src/umqtt.c
+++ b/src/umqtt.c
@@ -1673,7 +1673,7 @@ int umqtt_subscribe(struct umqtt_client *client, const char *topic, enum umqtt_q
         {    
             p_subtop = rt_list_entry(node, struct subtop_recv_handler, next_list);
             if (p_subtop->topicfilter 
-            && (rt_strncmp(p_subtop->topicfilter, topic, rt_strlen(topic)) == 0)) 
+            && (rt_strcmp(p_subtop->topicfilter, topic) == 0)) 
             {
                 LOG_D(" subscribe topic(%s) is already subscribed.", topic);
                 goto exit;


### PR DESCRIPTION
1. 如果先订阅了 `aaa` ，在订阅 `a` 的时候，会提示已经订阅了，这里的判断是不合理的
```
&& (rt_strncmp(p_subtop->topicfilter, topic, rt_strlen(topic)) == 0)) 
```
第二次订阅的时候 `a` 的长度是 `1`, 这里只会比较第一个字符，第一个字符的都是 `a` ，所以就会返回已经被订阅

2.  函数的形参不一致，会导致编译器警告